### PR TITLE
Make this work with composable buildpacks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -23,8 +23,8 @@ curl -L --silent $DOWNLOAD_URL_LAME | tar xz
 echo "exporting PATH and LIBRARY_PATH" | indent
 PROFILE_PATH="$BUILD_DIR/.profile.d/audiowaveform.sh"
 mkdir -p $(dirname $PROFILE_PATH)
-echo 'export PATH="$PATH:$HOME/vendor/audiowaveform/bin:$HOME/vendor/lame/bin"' >> $PROFILE_PATH
-echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/vendor/audiowaveform/lib:$HOME/vendor/lame/lib"' >> $PROFILE_PATH
+echo 'export PATH="$PATH:vendor/audiowaveform/bin:vendor/lame/bin"' >> $PROFILE_PATH
+echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:vendor/audiowaveform/lib:vendor/lame/lib"' >> $PROFILE_PATH
 
 . $PROFILE_PATH
 echo $LD_LIBRARY_PATH >> $ENV_DIR/LD_LIBRARY_PATH

--- a/bin/compile
+++ b/bin/compile
@@ -6,6 +6,7 @@ indent() {
 
 echo "-----> Installing audiowaveform and lame"
 BUILD_DIR=$1
+ENV_DIR=$3
 VENDOR_DIR="vendor"
 DOWNLOAD_URL_AUDIOWAVEFORM="https://github.com/Mattchewone/heroku-buildpack-audiowaveform/raw/master/audiowaveform.tar.gz"
 DOWNLOAD_URL_LAME="https://github.com/Mattchewone/heroku-buildpack-audiowaveform/raw/master/lame.tar.gz"
@@ -24,3 +25,6 @@ PROFILE_PATH="$BUILD_DIR/.profile.d/audiowaveform.sh"
 mkdir -p $(dirname $PROFILE_PATH)
 echo 'export PATH="$PATH:$HOME/vendor/audiowaveform/bin:$HOME/vendor/lame/bin"' >> $PROFILE_PATH
 echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/vendor/audiowaveform/lib:$HOME/vendor/lame/lib"' >> $PROFILE_PATH
+
+. $PROFILE_PATH
+echo $LD_LIBRARY_PATH >> $ENV_DIR/LD_LIBRARY_PATH


### PR DESCRIPTION
Hi Matt

Thanks for making this buildpack!

As with the LAME buildpack, it works fine with the new Heroku composable buildpack system, except that the LD_LIBRARY_PATH environment variable isn't set if subsequent buildpacks need it.

This PR does the same thing as https://github.com/lepinsk/heroku-buildpack-lame/pull/3 to allow later buildpacks to access LD_LIBRARY_PATH from this buildpack.

Let me know if you have any questions!